### PR TITLE
refactor: 更新主题配置，取消自定义字体

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
 // https://vitepress.dev/guide/custom-theme
 import { h } from "vue";
-import Theme from 'vitepress/theme-without-fonts' // https://vitepress.dev/zh/guide/extending-default-theme#using-different-fonts
+import Theme from 'vitepress/theme' // https://vitepress.dev/zh/guide/extending-default-theme#using-different-fonts
 // 引入组件库的少量全局样式变量
 import 'tdesign-vue-next/es/style/index.css';
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -3,11 +3,7 @@
 	font-family: "FiraCode";
 	src: url("/assets/fonts/FiraCode-VF.woff2");
 }
-/** 正文字体 */
-@font-face {
-	font-family: "SourceHanSerifCN";
-	src: local("SourceHanSerifCN"), url("/assets/fonts/SourceHanSerifCN-VF.woff2");
-}
+
 /** logo 字体 */
 @font-face {
 	font-family: "Niconne";
@@ -59,7 +55,6 @@
  * -------------------------------------------------------------------------- */
 
 :root {
-	--vp-font-family-base: "SourceHanSerifCN";
 	--vp-font-family-mono: "FiraCode";
 }
 
@@ -69,11 +64,6 @@
 	--td-brand-color-light: var(--vp-c-brand-soft) !important;
 	--td-brand-color-hover: var(--vp-c-brand-1) !important;
 	--td-brand-color-active: var(--vp-c-brand-2) !important;
-	/* 字体 family token */
-	--td-font-family: SourceHanSerifCN, PingFang SC, Microsoft YaHei,
-		Arial Regular;
-	--td-font-family-medium: SourceHanSerifCN, PingFang SC, Microsoft YaHei,
-		Arial Medium;
 }
 
 /**
@@ -83,7 +73,7 @@
 
 /* logo 字体设置 */
 .VPNavBarTitle .title {
-	font-family: "Niconne", "SourceHanSerifCN";
+	font-family: "Niconne";
 	font-size: 24px !important;
 }
 

--- a/docs/.vitepress/theme/utils/handleHeadMeta.ts
+++ b/docs/.vitepress/theme/utils/handleHeadMeta.ts
@@ -21,10 +21,7 @@ export function handleHeadMeta(context: TransformContext) {
     twitterCard, twitterDescription, twitterImage,
   ]
 
-  // 预加载字体
-  const preloadHead: HeadConfig[] = handleFontsPreload(context)
-
-  return [ ...twitterHead, ...preloadHead ]
+  return [ ...twitterHead ]
 }
 
 export function addBase(relativePath: string) {
@@ -34,26 +31,4 @@ export function addBase(relativePath: string) {
   } else {
     return host + '/' + relativePath
   }
-}
-
-export function handleFontsPreload({ assets }: TransformContext) {
-  // 只预加载正文字体，代码字体不预加载，因为可能不会使用或者很少使用
-  const SourceHanSerifCN = assets.find(file => /SourceHanSerifCN-VF\.\w+\.woff2/)
-  
-  if (SourceHanSerifCN) {
-    return [
-      [
-        'link',
-        {
-          rel: 'preload',
-          href: SourceHanSerifCN,
-          as: 'font',
-          type: 'font/woff2',
-          crossorigin: ''
-        }
-      ]
-    ] as HeadConfig[]
-  }
-
-  return []
 }


### PR DESCRIPTION
最终还是想把我的博客模板自定义字体换成默认字体了，兜兜转转又回来了😅

前面是默认字体，后面是之前的自定义字体（宋体）

![image](https://github.com/user-attachments/assets/2d10af8c-a58e-4fed-a344-aa1ed7a77dfd)

![image](https://github.com/user-attachments/assets/46b5a724-8c4d-413a-a2f5-23cef2867521)

我个人觉得出版物我喜欢宋体一点，比如微信读书我就设置宋体阅读，但最近不止一次收到反馈说字体不易阅读，确实有点细，而且在低分辨率屏幕下锯齿感挺严重的。